### PR TITLE
#10 added audio device tracking and made the translation box bigger

### DIFF
--- a/backend/src/nllb_to_icecast/audio_translation_orchestrator.py
+++ b/backend/src/nllb_to_icecast/audio_translation_orchestrator.py
@@ -364,15 +364,32 @@ class TranslationPipeline:
             return "Unknown"
 
         try:
+            import sounddevice as sd
             devices = self.audio_capture.list_audio_devices()
             device_index = self.audio_capture.device_index
 
-            if device_index is not None:
-                for device in devices:
-                    if device["index"] == device_index:
-                        return device["name"]
-        except:
-            pass
+            # If device_index is None, get the actual default device
+            if device_index is None:
+                try:
+                    device_index = sd.default.device[0]  # Get default input device
+                except:
+                    return "System Default (Unknown)"
+
+            # Find the device name by index
+            for device in devices:
+                if device["index"] == device_index:
+                    device_name = device["name"]
+                    # Check if this is the system default
+                    try:
+                        if device_index == sd.default.device[0]:
+                            return f"{device_name} (System Default)"
+                        else:
+                            return device_name
+                    except:
+                        return device_name
+                        
+        except Exception as e:
+            logger.error(f"Error getting device name: {e}")
 
         return "Default Device"
 

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -39,6 +39,7 @@
 	let audioLevel = 0;
 	let errorMessage = '';
 	let connectionStatus = 'Disconnected';
+	let currentAudioDevice = 'Not selected';
 
 	// WebSocket connection
 	function connectWebSocket() {
@@ -72,6 +73,7 @@
 						case 'status':
 							isRunning = message.data.is_running;
 							audioLevel = message.data.audio_level || 0;
+							currentAudioDevice = message.data.audio_device || 'Unknown';
 							break;
 						
 						case 'error':
@@ -207,6 +209,11 @@
 					{/each}
 				</select>
 			</div>
+		</div>
+
+		<div class="audio-device-info">
+			<label>🎤 Current Audio Input:</label>
+			<span class="device-name">{currentAudioDevice}</span>
 		</div>
 
 		<div class="action-buttons">
@@ -378,6 +385,35 @@
 		color: #6c757d;
 	}
 
+	.audio-device-info {
+		background: #e9f7ef;
+		border: 1px solid #c3e6cb;
+		border-radius: 8px;
+		padding: 1rem;
+		margin-bottom: 1.5rem;
+		display: flex;
+		align-items: center;
+		gap: 1rem;
+	}
+
+	.audio-device-info label {
+		font-weight: 600;
+		color: #155724;
+		margin: 0;
+	}
+
+	.device-name {
+		background: white;
+		padding: 0.5rem 1rem;
+		border-radius: 20px;
+		font-family: monospace;
+		font-size: 0.9rem;
+		color: #495057;
+		border: 1px solid #dee2e6;
+		flex: 1;
+		text-align: center;
+	}
+
 	.action-buttons {
 		display: flex;
 		justify-content: center;
@@ -454,8 +490,8 @@
 	}
 
 	.translation-display {
-		display: grid;
-		grid-template-columns: 1fr 1fr;
+		display: flex;
+		flex-direction: column;
 		gap: 2rem;
 	}
 
@@ -505,6 +541,14 @@
 
 	.translation-panel .text-output {
 		border-left-color: #28a745;
+		font-size: 5.5rem;
+		line-height: 1.2;
+		font-weight: 600;
+		text-align: center;
+		min-height: 300px;
+		display: flex;
+		align-items: center;
+		justify-content: center;
 	}
 
 	@media (max-width: 768px) {
@@ -518,8 +562,19 @@
 			margin: 0;
 		}
 
-		.translation-display {
-			grid-template-columns: 1fr;
+		.translation-panel .text-output {
+			font-size: 3rem;
+			min-height: 200px;
+		}
+
+		.audio-device-info {
+			flex-direction: column;
+			align-items: stretch;
+			gap: 0.5rem;
+		}
+
+		.audio-device-info label {
+			text-align: center;
 		}
 
 		.container {


### PR DESCRIPTION
This pull request improves both backend and frontend handling and display of the current audio input device in the audio translation application. The backend now more reliably determines and reports the audio device name, including system default detection, while the frontend displays this information prominently to users with enhanced styling.

**Backend audio device detection improvements:**

* Improved logic in `_get_audio_device_name` (`audio_translation_orchestrator.py`) to reliably detect and report the current audio input device, including handling for system default devices and better error logging.

**Frontend UI enhancements:**

* Added a new UI section to display the current audio input device (`+page.svelte`), updating the device name in real-time based on backend status messages. [[1]](diffhunk://#diff-277e5e66aac69da7616117de4cb91d3988aab163a62ebf7252f86fa6cf4b39eeR42) [[2]](diffhunk://#diff-277e5e66aac69da7616117de4cb91d3988aab163a62ebf7252f86fa6cf4b39eeR76) [[3]](diffhunk://#diff-277e5e66aac69da7616117de4cb91d3988aab163a62ebf7252f86fa6cf4b39eeR214-R218)
* Styled the audio device info section for clarity and responsiveness, including adjustments for mobile layouts. [[1]](diffhunk://#diff-277e5e66aac69da7616117de4cb91d3988aab163a62ebf7252f86fa6cf4b39eeR388-R416) [[2]](diffhunk://#diff-277e5e66aac69da7616117de4cb91d3988aab163a62ebf7252f86fa6cf4b39eeL521-R577)
* Improved the appearance of translation output panels for better readability and user experience. [[1]](diffhunk://#diff-277e5e66aac69da7616117de4cb91d3988aab163a62ebf7252f86fa6cf4b39eeR544-R551) [[2]](diffhunk://#diff-277e5e66aac69da7616117de4cb91d3988aab163a62ebf7252f86fa6cf4b39eeL457-R494)