### PR TITLE
#12 Added Japanese as a supported language

### DIFF
--- a/backend/src/nllb_to_icecast/audio_translation_orchestrator.py
+++ b/backend/src/nllb_to_icecast/audio_translation_orchestrator.py
@@ -251,6 +251,7 @@ class TranslationPipeline:
             "zh": "chinese",
             "fa": "farsi",
             "ru": "russian",
+            "ja": "japanese",
         }
 
         # Convert Whisper language code to full name

--- a/backend/src/nllb_to_icecast/processing/nllb_translator.py
+++ b/backend/src/nllb_to_icecast/processing/nllb_translator.py
@@ -21,6 +21,7 @@ LANGUAGE_CODES = {
     "farsi": "pes_Arab",
     "persian": "pes_Arab",  # Alias for Farsi
     "russian": "rus_Cyrl",
+    "japanese": "jpn_Jpan",
     # Common language codes
     "en": "eng_Latn",
     "es": "spa_Latn",
@@ -30,6 +31,7 @@ LANGUAGE_CODES = {
     "zh": "zho_Hans",
     "fa": "pes_Arab",
     "ru": "rus_Cyrl",
+    "ja": "jpn_Jpan",
 }
 
 

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -11,7 +11,8 @@
 		{ code: 'ko', name: 'Korean', nllbCode: 'korean' },
 		{ code: 'zh', name: 'Chinese', nllbCode: 'mandarin' },
 		{ code: 'fa', name: 'Farsi/Persian', nllbCode: 'farsi' },
-		{ code: 'ru', name: 'Russian', nllbCode: 'russian' }
+		{ code: 'ru', name: 'Russian', nllbCode: 'russian' },
+		{ code: 'ja', name: 'Japanese', nllbCode: 'japanese' }
 	];
 
 	const outputLanguages = [
@@ -22,7 +23,8 @@
 		{ code: 'mandarin', name: 'Chinese/Mandarin' },
 		{ code: 'farsi', name: 'Farsi/Persian' },
 		{ code: 'russian', name: 'Russian' },
-		{ code: 'english', name: 'English' }
+		{ code: 'english', name: 'English' },
+		{ code: 'japanese', name: 'Japanese' }
 	];
 
 	// State variables


### PR DESCRIPTION
This pull request adds support for Japanese language translation throughout the application. The changes ensure Japanese is recognized and mapped correctly in both the backend and frontend, allowing users to select Japanese as an input or output language.

**Backend language mapping updates:**

* Added `"ja": "japanese"` to the Whisper language code-to-name mapping in `_handle_translation` in `audio_translation_orchestrator.py`.
* Mapped `"japanese"` and `"ja"` to the NLLB code `"jpn_Jpan"` in `nllb_translator.py`, ensuring correct translation model selection for Japanese. [[1]](diffhunk://#diff-14e4b7fde83ed34916a8e06a57a524fcc5ca54bbe58826d58ac8b9957c6e3d4aR24) [[2]](diffhunk://#diff-14e4b7fde83ed34916a8e06a57a524fcc5ca54bbe58826d58ac8b9957c6e3d4aR34)

**Frontend language selection updates:**

* Added Japanese (`{ code: 'ja', name: 'Japanese', nllbCode: 'japanese' }`) to the `inputLanguages` array in `+page.svelte`, allowing users to select Japanese as an input language.
* Added Japanese (`{ code: 'japanese', name: 'Japanese' }`) to the `outputLanguages` array in `+page.svelte`, enabling Japanese as an output translation option.